### PR TITLE
Hotfix/20221108

### DIFF
--- a/src/executable.js
+++ b/src/executable.js
@@ -38,7 +38,7 @@ export class Executable extends mix(NamedDefaultableInMemoryEntity).with(Runtime
         let flavor = this.getEntityByName(this.flavors, "flavor", name);
         if (!flavor) {
             console.warn(`Could not find flavor '${name}'! Using default instead.`);
-            flavor = this.defaultFlavor;
+            flavor = this.getEntityByName(this.flavors, "flavor", undefined); // extracts default flavor
         }
         return flavor;
     }

--- a/src/executable.js
+++ b/src/executable.js
@@ -1,13 +1,10 @@
-import { mix } from "mixwith";
 import { NamedDefaultableInMemoryEntity, RuntimeItemsMixin } from "@exabyte-io/code.js/dist/entity";
+import { mix } from "mixwith";
+
 import { Flavor } from "./flavor";
 
 export class Executable extends mix(NamedDefaultableInMemoryEntity).with(RuntimeItemsMixin) {
     static Flavor = Flavor;
-
-    constructor(config) {
-        super(config);
-    }
 
     toJSON(exclude) {
         return super.toJSON(["flavors"].concat(exclude));
@@ -18,18 +15,18 @@ export class Executable extends mix(NamedDefaultableInMemoryEntity).with(Runtime
     }
 
     get flavors() {
-        return Object.keys(this.flavorsTree).map(key => {
-            return this.constructor.Flavor.create(
-                Object.assign({}, this.flavorsTree[key], {name: key, executable: this})
-            );
+        return Object.keys(this.flavorsTree).map((key) => {
+            return this.constructor.Flavor.create({
+                ...this.flavorsTree[key],
+                name: key,
+                executable: this,
+            });
         });
     }
 
     get flavorsFromTree() {
-        return Object.keys(this.flavorsTree).map(key => {
-            return new this.constructor.Flavor(
-                Object.assign({}, this.flavorsTree[key], {name: key})
-            );
+        return Object.keys(this.flavorsTree).map((key) => {
+            return new this.constructor.Flavor({ ...this.flavorsTree[key], name: key });
         });
     }
 
@@ -38,11 +35,15 @@ export class Executable extends mix(NamedDefaultableInMemoryEntity).with(Runtime
     }
 
     getFlavorByName(name) {
-        return this.getEntityByName(this.flavors, "flavor", name);
+        let flavor = this.getEntityByName(this.flavors, "flavor", name);
+        if (!flavor) {
+            console.warn(`Could not find flavor '${name}'! Using default instead.`);
+            flavor = this.defaultFlavor;
+        }
+        return flavor;
     }
 
     getFlavorByConfig(config) {
         return config ? this.getFlavorByName(config.name) : this.defaultFlavor;
     }
-
 }


### PR DESCRIPTION
`getEntityByName` will return `undefined` if the flavor doesn't exist anymore. This change will attempt to extract the default flavor instead in such a case.