### PR TITLE
feat: Add isUsingMaterial method to the application class

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -116,4 +116,9 @@ export class Application extends NamedDefaultableInMemoryEntity {
     get isLicensed() {
         return this.prop("isLicensed");
     }
+
+    get isUsingMaterial() {
+        const materialUsingApplications = ["vasp", "nwchem", "espresso"];
+        return materialUsingApplications.includes(this.name);
+    }
 }


### PR DESCRIPTION
- `isUsingMaterial` getter added to application to filter for application names: `nwchem`, `espresso`, or `vasp`
- see: https://github.com/Exabyte-io/web-app/pull/2494